### PR TITLE
feat: support for opentelemetry spec conventions

### DIFF
--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "graphql-otel",
-  "version": "0.0.11",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "graphql-otel",
-      "version": "0.0.11",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/utils": "^10.0.4",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-otel",
-  "version": "0.0.11",
+  "version": "0.1.0",
   "description": "Opentelemetry GraphQL Schema Directives.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,3 +1,3 @@
-export { traceDirective } from "./trace-directive";
-export { GraphQLOTELContext } from "./context";
-export { runInSpan, RunInChildSpanOptions } from "./run-in-span";
+export * from "./trace-directive";
+export * from "./context";
+export * from "./run-in-span";

--- a/package/src/trace-directive.ts
+++ b/package/src/trace-directive.ts
@@ -10,9 +10,12 @@ import safeJSON from "safe-json-stringify";
 export enum AttributeName {
   OPERATION_NAME = "graphql.operation.name",
   OPERATION_TYPE = "graphql.operation.type",
+
   DOCUMENT = "graphql.document",
-  ARGS = "graphql.operation.args", // Non-Spec attribute
-  CONTEXT = "graphql.operation.context", // Non-Spec attribute
+  OPERATION_ARGS = "graphql.operation.args", // Non-Spec attribute
+  OPERATION_CONTEXT = "graphql.operation.context", // Non-Spec attribute
+  OPERATION_RESULT = "graphql.operation.result", // Non-Spec attribute
+  OPERATION_RETURN_TYPE = "graphql.operation.returnType", // Non-Spec attribute
 }
 
 export function traceDirective(directiveName = "trace") {
@@ -89,12 +92,15 @@ export function traceDirective(directiveName = "trace") {
                     [AttributeName.OPERATION_TYPE]:
                       info.operation.operation.toLowerCase(),
                     [AttributeName.DOCUMENT]: print(info.operation),
+                    [AttributeName.OPERATION_RETURN_TYPE]:
+                      info.returnType.toString(),
                     ...(internalCtx.includeVariables
-                      ? { [AttributeName.ARGS]: safeJSON(args) }
+                      ? { [AttributeName.OPERATION_ARGS]: safeJSON(args) }
                       : {}),
                     ...(internalCtx.includeContext
                       ? {
-                          [AttributeName.CONTEXT]: safeJSON(attributeContext),
+                          [AttributeName.OPERATION_CONTEXT]:
+                            safeJSON(attributeContext),
                         }
                       : {}),
                   },
@@ -114,9 +120,12 @@ export function traceDirective(directiveName = "trace") {
                       typeof result === "string" ||
                       typeof result === "boolean"
                     ) {
-                      span.setAttribute("result", result);
+                      span.setAttribute(AttributeName.OPERATION_RESULT, result);
                     } else if (typeof result === "object") {
-                      span.setAttribute("result", safeJSON(result || {}));
+                      span.setAttribute(
+                        AttributeName.OPERATION_RESULT,
+                        safeJSON(result || {})
+                      );
                     }
                   }
 

--- a/package/src/trace-directive.ts
+++ b/package/src/trace-directive.ts
@@ -6,6 +6,15 @@ import { Span } from "@opentelemetry/sdk-trace-base";
 import { runInSpan } from "./run-in-span";
 import safeJSON from "safe-json-stringify";
 
+// Matching spec https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/instrumentation/graphql/
+export enum AttributeName {
+  OPERATION_NAME = "graphql.operation.name",
+  OPERATION_TYPE = "graphql.operation.type",
+  DOCUMENT = "graphql.document",
+  ARGS = "graphql.operation.args", // Non-Spec attribute
+  CONTEXT = "graphql.operation.context", // Non-Spec attribute
+}
+
 export function traceDirective(directiveName = "trace") {
   return {
     typeDefs: `directive @${directiveName} on FIELD_DEFINITION`,
@@ -43,11 +52,18 @@ export function traceDirective(directiveName = "trace") {
 
               const parentSpan = context.parentSpan as Span | undefined;
 
-              const isRoot = ["Query", "Mutation"].includes(
+              const isRoot = ["Query", "Mutation", "Subscription"].includes(
                 info.parentType.name
               );
 
-              const name = `${info.parentType.name}:${fieldConfig.astNode?.name.value}`;
+              let name = "";
+              if (isRoot) {
+                name = `${info.parentType.name.toLowerCase()} ${
+                  info.operation.name?.value || info.fieldName
+                }`;
+              } else {
+                name = `${info.parentType.name} ${fieldConfig.astNode?.name.value}`;
+              }
 
               const attributeContext = {
                 ...context,
@@ -68,21 +84,20 @@ export function traceDirective(directiveName = "trace") {
                   context: traceCTX,
                   tracer: internalCtx.tracer,
                   parentSpan,
-                  ...(isRoot
-                    ? {
-                        attributes: {
-                          query: print(info.operation),
-                          ...(internalCtx.includeVariables
-                            ? { variables: safeJSON(args) }
-                            : {}),
-                          ...(internalCtx.includeContext
-                            ? {
-                                context: safeJSON(attributeContext),
-                              }
-                            : {}),
-                        },
-                      }
-                    : {}),
+                  attributes: {
+                    [AttributeName.OPERATION_NAME]: info.fieldName,
+                    [AttributeName.OPERATION_TYPE]:
+                      info.operation.operation.toLowerCase(),
+                    [AttributeName.DOCUMENT]: print(info.operation),
+                    ...(internalCtx.includeVariables
+                      ? { [AttributeName.ARGS]: safeJSON(args) }
+                      : {}),
+                    ...(internalCtx.includeContext
+                      ? {
+                          [AttributeName.CONTEXT]: safeJSON(attributeContext),
+                        }
+                      : {}),
+                  },
                 },
                 async (span) => {
                   if (!internalCtx.getRootSpan()) {

--- a/package/tests/trace.test.ts
+++ b/package/tests/trace.test.ts
@@ -11,6 +11,7 @@ import { traceDirective } from "../src";
 import { graphql, parse, print } from "graphql";
 import { GraphQLOTELContext } from "../src/context";
 import { SpanStatusCode } from "@opentelemetry/api";
+import { AttributeName } from "../src/trace-directive";
 
 const util = require("util");
 const sleep = util.promisify(setTimeout);
@@ -181,21 +182,29 @@ describe("@trace directive", () => {
     const rootSpan = spans.find((span) => !span.parentSpanId) as ReadableSpan;
     const spanTree = buildSpanTree({ span: rootSpan, children: [] }, spans);
 
-    expect(spanTree.span.name).toEqual("Query:users");
-    expect(spanTree.span.attributes.query).toMatch(print(parse(query)));
+    expect(spanTree.span.name).toEqual("query users");
+    expect(spanTree.span.attributes[AttributeName.DOCUMENT]).toMatch(
+      print(parse(query))
+    );
+    expect(spanTree.span.attributes[AttributeName.OPERATION_NAME]).toMatch(
+      "users"
+    );
+    expect(spanTree.span.attributes[AttributeName.OPERATION_TYPE]).toMatch(
+      "query"
+    );
 
     const balanceSpan = spanTree.children.find(
-      (child) => child.span.name === "User:balance"
+      (child) => child.span.name === "User balance"
     );
     expect(balanceSpan).toBeDefined();
 
     const postsSpan = spanTree.children.find(
-      (child) => child.span.name === "User:posts"
+      (child) => child.span.name === "User posts"
     );
     expect(postsSpan).toBeDefined();
 
     const commentsSnap = postsSpan!.children.find(
-      (child) => child.span.name === "Post:comments"
+      (child) => child.span.name === "Post comments"
     );
     expect(commentsSnap).toBeDefined();
 
@@ -282,11 +291,13 @@ describe("@trace directive", () => {
     const rootSpan = spans.find((span) => !span.parentSpanId) as ReadableSpan;
     const spanTree = buildSpanTree({ span: rootSpan, children: [] }, spans);
 
-    expect(spanTree.span.name).toEqual("Mutation:createUser");
-    expect(spanTree.span.attributes.query).toMatch(print(parse(query)));
+    expect(spanTree.span.name).toEqual("mutation createUser");
+    expect(spanTree.span.attributes[AttributeName.DOCUMENT]).toMatch(
+      print(parse(query))
+    );
 
     const postsSpan = spanTree.children.find(
-      (child) => child.span.name === "User:posts"
+      (child) => child.span.name === "User posts"
     );
     expect(postsSpan).toBeDefined();
   });
@@ -345,8 +356,10 @@ describe("@trace directive", () => {
     const rootSpan = spans.find((span) => !span.parentSpanId) as ReadableSpan;
     const spanTree = buildSpanTree({ span: rootSpan, children: [] }, spans);
 
-    expect(spanTree.span.name).toEqual("Query:users");
-    expect(spanTree.span.attributes.query).toMatch(print(parse(query)));
+    expect(spanTree.span.name).toEqual("query users");
+    expect(spanTree.span.attributes[AttributeName.DOCUMENT]).toMatch(
+      print(parse(query))
+    );
 
     const events = spanTree.span.events;
 
@@ -426,15 +439,21 @@ describe("@trace directive", () => {
     const rootSpan = spans.find((span) => !span.parentSpanId) as ReadableSpan;
     const spanTree = buildSpanTree({ span: rootSpan, children: [] }, spans);
 
-    expect(spanTree.span.name).toEqual("Query:users");
-    expect(spanTree.span.attributes.query).toMatch(print(parse(query)));
+    expect(spanTree.span.name).toEqual("query users");
+    expect(spanTree.span.attributes[AttributeName.DOCUMENT]).toMatch(
+      print(parse(query))
+    );
 
-    const variables = JSON.parse(spanTree.span.attributes.variables as string);
+    const variables = JSON.parse(
+      spanTree.span.attributes[AttributeName.ARGS] as string
+    );
     expect(variables).toMatchObject({
       name: randomName,
     });
 
-    const context = JSON.parse(spanTree.span.attributes.context as string);
+    const context = JSON.parse(
+      spanTree.span.attributes[AttributeName.CONTEXT] as string
+    );
     expect(context).toMatchObject({
       name: randomName,
     });
@@ -467,7 +486,7 @@ describe("@trace directive", () => {
     schema = trace.transformer(schema);
 
     const query = `
-      query {
+      query getRandomString {
         randomString
       }
     `;
@@ -488,8 +507,10 @@ describe("@trace directive", () => {
     const rootSpan = spans.find((span) => !span.parentSpanId) as ReadableSpan;
     const spanTree = buildSpanTree({ span: rootSpan, children: [] }, spans);
 
-    expect(spanTree.span.name).toEqual("Query:randomString");
-    expect(spanTree.span.attributes.query).toMatch(print(parse(query)));
+    expect(spanTree.span.name).toEqual("query getRandomString");
+    expect(spanTree.span.attributes[AttributeName.DOCUMENT]).toMatch(
+      print(parse(query))
+    );
 
     const result = spanTree.span.attributes.result;
 

--- a/package/tests/trace.test.ts
+++ b/package/tests/trace.test.ts
@@ -443,16 +443,19 @@ describe("@trace directive", () => {
     expect(spanTree.span.attributes[AttributeName.DOCUMENT]).toMatch(
       print(parse(query))
     );
+    expect(
+      spanTree.span.attributes[AttributeName.OPERATION_RETURN_TYPE]
+    ).toMatch("[User]");
 
     const variables = JSON.parse(
-      spanTree.span.attributes[AttributeName.ARGS] as string
+      spanTree.span.attributes[AttributeName.OPERATION_ARGS] as string
     );
     expect(variables).toMatchObject({
       name: randomName,
     });
 
     const context = JSON.parse(
-      spanTree.span.attributes[AttributeName.CONTEXT] as string
+      spanTree.span.attributes[AttributeName.OPERATION_CONTEXT] as string
     );
     expect(context).toMatchObject({
       name: randomName,
@@ -512,7 +515,7 @@ describe("@trace directive", () => {
       print(parse(query))
     );
 
-    const result = spanTree.span.attributes.result;
+    const result = spanTree.span.attributes[AttributeName.OPERATION_RESULT];
 
     expect(result).toEqual(randomString);
   });


### PR DESCRIPTION
Changes the span attribute naming conventions to follow that of https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/instrumentation/graphql/

